### PR TITLE
fix(cfn-resources): update repository url

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -9,7 +9,7 @@ const project = new typescript.TypeScriptProject({
   bin: {
     'cfn-resources': 'lib/cli.js',
   },
-  repositoryUrl: 'https://github.com/cdklabs/cfn-resources',
+  repository: 'https://github.com/cdklabs/cfn-resources',
   autoApproveOptions: {
     allowedUsernames: ['cdklabs-automation'],
     secret: 'GITHUB_TOKEN',

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -9,6 +9,7 @@ const project = new typescript.TypeScriptProject({
   bin: {
     'cfn-resources': 'lib/cli.js',
   },
+  repositoryUrl: 'https://github.com/cdklabs/cfn-resources',
   autoApproveOptions: {
     allowedUsernames: ['cdklabs-automation'],
     secret: 'GITHUB_TOKEN',

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
   "name": "cfn-resources",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/cdklabs/cfn-resources"
+  },
   "bin": {
     "cfn-resources": "lib/cli.js"
   },


### PR DESCRIPTION
Fixes npm publish issue `Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/cdklabs/cfn-resources" from provenance`